### PR TITLE
Sync search params

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -92,7 +92,8 @@ gsap.registerPlugin(useGSAP);
 //   { ssr: false }
 // );
 export default function Home() {
-  const { data, filteredData, fetchData } = useMapStore();
+  const { data, filteredData } = useMapStore();
+
   const [isDesktop, setIsDesktop] = useState(false);
   // const [data, setData] = useState([]);
   const [isExpanded, setIsExpanded] = useState(false);
@@ -107,9 +108,6 @@ export default function Home() {
   const handleMouseLeave = useCallback(() => {
     setIsExpanded(false);
   }, []);
-  useEffect(() => {
-    fetchData();
-  }, [fetchData]);
 
   useEffect(() => {
     setIsDesktop(window.innerWidth >= 820);
@@ -181,9 +179,7 @@ export default function Home() {
             className="mt-4 flex-grow flex flex-col h-[400px] desktop:h-auto"
             id="scatterplot-container"
           >
-            <h2 className="text-lg font-bold ml-8">
-              Heat worry and Heat rating of all counties
-            </h2>
+            <h2 className="text-lg font-bold ml-8">Heat worry and Heat rating of all counties</h2>
             <figure className="w-full flex-grow">
               <ParentSize>
                 {({ width, height, top, left }) => {
@@ -223,8 +219,6 @@ export default function Home() {
           </aside>
         </section>
       </main>
-
-     
     </>
   );
 }

--- a/src/components/containers/ExpandableSection.tsx
+++ b/src/components/containers/ExpandableSection.tsx
@@ -11,18 +11,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-import {
-  FireIcon,
-  LifebuoyIcon,
-  Bars2Icon,
-  CloudIcon,
-  SunIcon,
-} from "@heroicons/react/24/outline";
-export default function ExpandableSection({
-  isExpanded,
-  isDesktop,
-  categories,
-}) {
+import { FireIcon, LifebuoyIcon, Bars2Icon, CloudIcon, SunIcon } from "@heroicons/react/24/outline";
+export default function ExpandableSection({ isExpanded, isDesktop, categories }) {
   const [expandedCategory, setExpandedCategory] = useState("Heat");
   const [selectedSubcategory, setSelectedSubcategory] = useState("Heat gap");
   const buttonRefs = useRef([]);
@@ -30,9 +20,7 @@ export default function ExpandableSection({
   const [selectedIndex, setSelectedIndex] = useState(0);
   const listRef = useRef(null);
   const toggleCategory = (categoryName) => {
-    setExpandedCategory(
-      expandedCategory === categoryName ? null : categoryName
-    );
+    setExpandedCategory(expandedCategory === categoryName ? null : categoryName);
   };
   const handleSubcategoryClick = (subcategory, index) => {
     setSelectedSubcategory(subcategory);
@@ -44,22 +32,17 @@ export default function ExpandableSection({
       <nav
         aria-label="Sidebar"
         className={`
-            overflow-hidden
-            absolute
-          
-         order-1 flex-grow-0 flex-shrink-0
-       border-gray-200
-       text-white
-     z-[111] 
-        w-60 h-full transition-all duration-[800] ease-in-out
-        space-y-4
-         px-4 flex flex-col
-        ${
-          isExpanded
-            ? "translate-x-0 opacity-100"
-            : "-translate-x-full opacity-0"
-        }
-      `}
+          overflow-hidden
+          absolute
+          order-1 flex-grow-0 flex-shrink-0
+          border-gray-200
+          text-white
+          z-[40] 
+          w-60 h-full transition-all duration-[800] ease-in-out
+          space-y-4
+          px-4 flex flex-col
+          ${isExpanded ? "translate-x-0 opacity-100" : "-translate-x-full opacity-0"}
+        `}
         aria-hidden={!isExpanded}
       >
         <div id="sidebar-background"></div>
@@ -85,10 +68,7 @@ export default function ExpandableSection({
 
         {isDesktop && (
           <>
-            <div
-              className="flex-grow flex flex-col justify-between"
-              id="sidebar-content"
-            >
+            <div className="flex-grow flex flex-col justify-between" id="sidebar-content">
               <section className="mb-4">
                 {categories.map((category, i) => (
                   <div key={category.name} className="overflow-hidden ">
@@ -105,9 +85,7 @@ export default function ExpandableSection({
                           case "storm":
                             return <CloudIcon className="size-6" />;
                           case "flood":
-                            return (
-                              <LifebuoyIcon className="size-6" />
-                            );
+                            return <LifebuoyIcon className="size-6" />;
                           case "drought":
                             return <SunIcon className="size-6" />;
                           default:
@@ -152,9 +130,7 @@ export default function ExpandableSection({
                         {category.subcategories.map((subcategory, index) => (
                           <li key={subcategory} className="relative">
                             <button
-                              onClick={() =>
-                                handleSubcategoryClick(subcategory, index)
-                              }
+                              onClick={() => handleSubcategoryClick(subcategory, index)}
                               className={`w-full text-left text-xs p-2 whitespace-pre hover:cursor-pointer relative z-10 ${
                                 selectedSubcategory === subcategory
                                   ? "text-white"

--- a/src/components/containers/Header.tsx
+++ b/src/components/containers/Header.tsx
@@ -1,30 +1,28 @@
-// @ts-nocheck
 import {
   Select,
   SelectContent,
-  SelectGroup,
   SelectItem,
-  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
 
 import { useMapStore } from "@/lib/store";
+import { useSearchParams } from "next/navigation";
 
 export const HeatGapHeader = () => {
-  const {
-    USStates,
-    selectedState,
-    setSelectedState,
-    selectedZoomCounty,
-    setSelectedZoomCounty,
-  } = useMapStore();
+  const searchParams = useSearchParams();
+  const state = searchParams.get("state");
+  const county = searchParams.get("county");
+  console.log({ state, county });
+
+  const { USStates, selectedState, setSelectedState, selectedZoomCounty, setSelectedZoomCounty } =
+    useMapStore();
 
   const getStateDataViaId = (id: string) => {
     const state = USStates.find((state) => state.id.toString() === id);
     return {
-      id: state.id,
-      name: state.name,
+      id: state!.id,
+      name: state!.name,
     };
   };
 
@@ -36,7 +34,7 @@ export const HeatGapHeader = () => {
 
   const handleCountyChange = (value: string) => {
     const selectedCountyData = USStates.find(
-      (state) => state.name === selectedState.name
+      (state) => state?.name === selectedState.name
     )?.counties.find((county) => county.geoID.toString() === value);
 
     if (selectedCountyData) {
@@ -52,10 +50,7 @@ export const HeatGapHeader = () => {
       <div className="flex items-center space-x-4">
         <h2 className="text-2xl font-bold text-blue-900">Heat gap</h2>
         <span className="text-gray-600">in</span>
-        <Select
-          defaultValue={selectedState.name}
-          onValueChange={handleStateChange}
-        >
+        <Select defaultValue={selectedState.name} onValueChange={handleStateChange}>
           <SelectTrigger className="w-[180px]">
             <SelectValue>{selectedState.name}</SelectValue>
           </SelectTrigger>
@@ -79,8 +74,7 @@ export const HeatGapHeader = () => {
           </SelectTrigger>
           <SelectContent>
             {USStates.find(
-              (state) =>
-                state.name === selectedState.name && state.name !== "US"
+              (state) => state.name === selectedState.name && state.name !== "US"
             )?.counties.map((county) => (
               <SelectItem key={county.geoID} value={county.geoID.toString()}>
                 {county.countyName}

--- a/src/components/containers/Header.tsx
+++ b/src/components/containers/Header.tsx
@@ -7,14 +7,8 @@ import {
 } from "@/components/ui/select";
 
 import { useMapStore } from "@/lib/store";
-import { useSearchParams } from "next/navigation";
 
 export const HeatGapHeader = () => {
-  const searchParams = useSearchParams();
-  const state = searchParams.get("state");
-  const county = searchParams.get("county");
-  console.log({ state, county });
-
   const { USStates, selectedState, setSelectedState, selectedZoomCounty, setSelectedZoomCounty } =
     useMapStore();
 

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,4 +1,4 @@
-import { useStore, createStore } from "zustand";
+import { useStore, createStore, type StoreApi } from "zustand";
 import { scaleQuantize } from "d3-scale";
 import { csv } from "d3-fetch";
 
@@ -12785,7 +12785,7 @@ type IDatum = {
 type IState = { name: string; id: number };
 type ICounty = { geoID: string; countyName: string };
 
-const state = {
+const storeState = {
   selectedState: { id: 0, name: "US" },
   selectedZoomCounty: { geoID: "", countyName: "" },
   selectedCounties: [] as ICounty[],
@@ -12794,9 +12794,13 @@ const state = {
   colorScale: createColorScale(),
 };
 
-type MapState = typeof state;
-const store = createStore<MapState>((set, get) => ({
-  ...state,
+type IMapState = typeof storeState;
+const createActions = (
+  set: StoreApi<IMapState>["setState"],
+  get: StoreApi<IMapState>["getState"],
+  _store: StoreApi<IMapState>
+) => ({
+  ...({} as IMapState),
   setSelectedState: (state: IState) => {
     set({ selectedState: state });
     const { data } = get();
@@ -12825,6 +12829,12 @@ const store = createStore<MapState>((set, get) => ({
     const filtered = stateName === "US" ? data : data.filter((d) => d.state === stateName);
     set({ filteredData: filtered });
   },
+});
+
+type IActions = ReturnType<typeof createActions>;
+const store = createStore<IMapState & IActions>((set, get, store) => ({
+  ...storeState,
+  ...createActions(set, get, store),
 }));
 
 export const useMapStore = () => useStore(store);

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -21,7 +21,14 @@ const createColorScale = () => {
   return scaleQuantize().domain(domain).range(range);
 };
 
+const THE_US_DUMMY_STATE = {
+  id: 0,
+  name: "US",
+  counties: [],
+};
+
 const USStates = [
+  THE_US_DUMMY_STATE,
   {
     id: 10,
     name: "Delaware",
@@ -12758,10 +12765,6 @@ const USStates = [
       },
     ],
   },
-  {
-    id: 0,
-    name: "US",
-  },
 ];
 
 const sortedUSStates = USStates.sort((a, b) => {
@@ -12782,11 +12785,11 @@ type IDatum = {
   isBrushed: boolean;
 };
 
-type IState = { name: string; id: number };
+type IState = { name: string; id: number; counties?: ICounty[] };
 type ICounty = { geoID: string; countyName: string };
 
 const storeState = {
-  selectedState: { id: 0, name: "US" },
+  selectedState: THE_US_DUMMY_STATE as IState,
   selectedZoomCounty: { geoID: "", countyName: "" },
   selectedCounties: [] as ICounty[],
   data: [] as IDatum[],

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,6 @@
-import { type ClassValue, clsx } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
 }


### PR DESCRIPTION
Instead of zustand `create(initializer)`, switch to use `mapStore = createStore(initializer)` and then `useStore(mapStore)`. This way we get a vanilla store that does not interfere with React (no implicit calls to any react hooks). The syncing of URL search params and store state is done purely in vanilla JS, does not rely on any react feature.

I also trigger `fetchData` (renamed to `reloadMapStoreData`) in advance. I don't see any reason why we need to wait for react mounting.